### PR TITLE
Fixed voiding of wrong patient HIV staging information.

### DIFF
--- a/src/components/PatientInformation.vue
+++ b/src/components/PatientInformation.vue
@@ -823,10 +823,19 @@ export default {
       let url = `/patients/${this.$route.params.id}/drugs_orders_by_program?program_id=1`;
       let observations = await ApiClient.get(url);
       return await observations.json();
+    },
+    /**
+     * Clear all cached patient data in global state.
+     */
+    clearStore() {
+      this.$store.commit('setInitialRegistration', {});
+      this.$store.commit('setInitialVitals', {});
+      this.$store.commit('setInitialStaging', {});
     }
   },
   mounted() {
     this.getPrefix();
+    this.clearStore(); 
     this.patientID = this.$route.params.id;
     this.getPatient().then(patient => {
       this.name = `${patient["person"].names[0].given_name} ${patient.person.names[0].family_name}`;

--- a/src/components/encounters/Registration.vue
+++ b/src/components/encounters/Registration.vue
@@ -556,21 +556,14 @@ export default {
       });
     },
     voidFirstVisitEncounters() {
-      let encounters = [];
+      const encounters = [this.$store.state.initialRegistration,
+                          this.$store.state.initialVitals,
+                          this.$store.state.initialStaging];
 
-      try {
-        encounters.push(this.$store.state.initialRegistration["encounter_id"]);
-      } catch (error) {}
+      const encounterIds = encounters.map(encounter => encounter?.encounter_id)
+                                     .filter(encounter_id => encounter_id != null);
 
-      try {
-        encounters.push(this.$store.state.initialVitals["encounter_id"]);
-      } catch (error) {}
-
-      try {
-        encounters.push(this.$store.state.initialStaging["encounter_id"]);
-      } catch (error) {}
-
-      this.voidEncounters(encounters);
+      this.voidEncounters(encounterIds);
     }
   },
   mounted() {


### PR DESCRIPTION
For every patient mastercard loaded, staging information is cached in
the VueX store, however this cached data is never invalidated and only updated
when a patient with staging information is loaded. In cases where a patient
without staging information is loaded that other patient staging information was
still in the cache. So an update of staging information was resulting in the
existing information being voided first before saving of the new information.

This patch fixes that issue by clearing the data first when the mastercard is loaded.